### PR TITLE
Add accessibility note on autoplaying content

### DIFF
--- a/modules/demos/auto-play/auto-play.hbs
+++ b/modules/demos/auto-play/auto-play.hbs
@@ -4,6 +4,10 @@
 
 <p>Auto-playing will pause when mouse is hovered over, and resume when mouse is hovered off. Auto-playing will stop when the carousel is clicked or a cell is selected.</p>
 
+<div class="call-out">
+  <p>Autoplaying content can be disorientating for some users. It's best to offer an option to pause or stop the carousel <a href="api.html#player">. See Example</a>.</p>
+</div>
+
 <div class="example duo">
   <div class="example__code duo__cell">
     ``` js


### PR DESCRIPTION
As part of the WCAG guidelines, any auto-playing content lasting more than 5 seconds should be able to be paused or stopped by the user. https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide.html

As the `autoPlay` setting is optional, it's worth adding a note to let people know that this can cause issues for users.

An example of this might be someone with a vestibular disorder. https://alistapart.com/article/accessibility-for-vestibular/